### PR TITLE
Add CSV parsing tests

### DIFF
--- a/csv.js
+++ b/csv.js
@@ -1,0 +1,26 @@
+function splitCSVLine(line) {
+  const out = [], re = /\s*(?:"([^"]*)"|([^",]*))\s*(,|$)/g;
+  let m;
+  while ((m = re.exec(line)) !== null) {
+    out.push(m[1] ?? m[2]);
+    if (m[3] !== ',') break;
+  }
+  return out;
+}
+
+function parseCSV(text) {
+  const lines = text.trim().split(/\r?\n/);
+  if (lines.length < 2) return [];
+  const headers = splitCSVLine(lines[0]).map((s) => s.trim().toLowerCase());
+  const out = [];
+  for (let i = 1; i < lines.length; i++) {
+    const cols = splitCSVLine(lines[i]);
+    if (cols.length === 0) continue;
+    const o = {};
+    headers.forEach((h, idx) => (o[h] = cols[idx] ?? ''));
+    out.push(o);
+  }
+  return out;
+}
+
+module.exports = { splitCSVLine, parseCSV };

--- a/csv.test.js
+++ b/csv.test.js
@@ -1,0 +1,34 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { splitCSVLine, parseCSV } = require('./csv');
+
+test('splitCSVLine handles quoted fields', () => {
+  assert.deepStrictEqual(splitCSVLine('"a","b"'), ['a', 'b']);
+});
+
+test('splitCSVLine handles commas inside quotes', () => {
+  assert.deepStrictEqual(splitCSVLine('"a,b",c'), ['a,b', 'c']);
+});
+
+test('splitCSVLine handles empty fields', () => {
+  assert.deepStrictEqual(splitCSVLine('a,,c'), ['a', '', 'c']);
+});
+
+test('parseCSV handles uneven columns', () => {
+  const csv = 'a,b,c\n1,2\n3,4,5,6';
+  const rows = parseCSV(csv);
+  assert.deepStrictEqual(rows, [
+    { a: '1', b: '2', c: '' },
+    { a: '3', b: '4', c: '5' },
+  ]);
+});
+
+test('parseCSV handles quotes and commas', () => {
+  const csv = 'name,age\n"Smith, Bob",30\nJane,\n"A,B",1';
+  const rows = parseCSV(csv);
+  assert.deepStrictEqual(rows, [
+    { name: 'Smith, Bob', age: '30' },
+    { name: 'Jane', age: '' },
+    { name: 'A,B', age: '1' },
+  ]);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "breiflylawapp",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- expose `parseCSV` and `splitCSVLine` helpers in a Node module
- add node:test-based suite for CSV edge cases (quotes, commas, empty fields, uneven columns)
- wire up `npm test` to run the Node test runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e6a25f09c8326861a39c3d54b11f9